### PR TITLE
Add a command to set .country on areas (and assess ambiguities)

### DIFF
--- a/mapit_global/fixtures/global.json
+++ b/mapit_global/fixtures/global.json
@@ -25,5 +25,7 @@
 
     { "pk": 1, "model": "mapit.codetype", "fields": { "code": "osm_rel", "description": "OSM relation" } },
     { "pk": 2, "model": "mapit.codetype", "fields": { "code": "osm_way", "description": "OSM way" } },
-    { "pk": 3, "model": "mapit.codetype", "fields": { "code": "osm_attr_ref", "description": "OSM reference attribute" } }
+    { "pk": 3, "model": "mapit.codetype", "fields": { "code": "osm_attr_ref", "description": "OSM reference attribute" } },
+    { "pk": 4, "model": "mapit.codetype", "fields": { "code": "iso3166_1", "description": "ISO3166-1 country code from OSM" } }
+
 ]

--- a/mapit_global/management/commands/mapit_global_update_countries.py
+++ b/mapit_global/management/commands/mapit_global_update_countries.py
@@ -1,0 +1,132 @@
+from __future__ import print_function, unicode_literals
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils.functional import cached_property
+from lxml import etree
+import requests
+
+from mapit.models import Area, Code, CodeType, Country, Generation
+
+
+class Command(BaseCommand):
+
+    OSM_COUNTRY_CODE_KEY = 'ISO3166-1'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--commit', action='store_true')
+        parser.add_argument('--generation', required=True, type=int)
+
+    @cached_property
+    def generation_kwargs(self):
+        return {
+            'generation_low__lte': self.generation,
+            'generation_high__gte': self.generation,
+        }
+
+    def set_country_codes_for_countries(self):
+        country_areas_qs = Area.objects.filter(
+            type__code='O02', **self.generation_kwargs)
+        for area in country_areas_qs:
+            area.codes.filter(type=self.iso_code_type).delete()
+            code = area.codes.get(type__code__in=('osm_rel', 'osm_way'))
+            osm_type = {
+                'osm_rel': 'relation',
+                'osm_way': 'way',
+            }[code.type.code]
+            api_url = 'http://api.openstreetmap.org/api/0.6/{0}/{1}'.format(osm_type, code.code)
+            print('api_url:', api_url)
+            r = requests.get(api_url)
+            if r.status_code == 410:
+                # We can get a "410 Gone" response if a relation or
+                # way has been removed since the last import of
+                # boundary data from OSM, in which case we should just
+                # skip over that area.
+                continue
+            r.raise_for_status()
+            root = etree.fromstring(r.content)
+            tags = root.xpath('//tag[@k="{0}"]'.format(self.OSM_COUNTRY_CODE_KEY))
+            if not tags:
+                continue
+            if len(tags) > 1:
+                msg = 'More than one {0} tag found for {1}'
+                raise Exception(msg.format(self.OSM_COUNTRY_CODE_KEY, area))
+            country_code = tags[0].attrib['v']
+            Code.objects.create(area=area, type=self.iso_code_type, code=country_code)
+
+    def ensure_countries_exist(self):
+        for code_object in self.iso_code_type.codes.select_related('area'):
+            Country.objects.get_or_create(
+                code=code_object.code,
+                defaults={'name': code_object.area.name})
+        Country.objects.get_or_create(
+            code='?',
+            defaults={'name': 'Multiple enclosing countries'})
+
+    @cached_property
+    def iso_code_type(self):
+        return CodeType.objects.get_or_create(
+            code='iso3166_1',
+            defaults={'description': 'ISO3166-1 country code from OSM'})[0]
+
+    def get_enclosing_country_codes(self, area):
+        enclosing_country_codes = set()
+        for polygon_object in area.polygons.all():
+            point = polygon_object.polygon.point_on_surface
+            # Now find the country-level areas that contain that point:
+            for enclosing_country_area in Area.objects.filter(
+                    type__code='O02',
+                    codes__type=self.iso_code_type,
+                    polygons__polygon__contains=point,
+                    **self.generation_kwargs
+            ):
+                country_code_object = enclosing_country_area.codes.get(type=self.iso_code_type)
+                enclosing_country_codes.add(country_code_object.code)
+        return tuple(sorted(enclosing_country_codes))
+
+    def get_country_from_codes(self, country_codes):
+        if not country_codes:
+            return None
+        if len(country_codes) > 1:
+            unique_country_code = '?'
+        else:
+            unique_country_code = next(iter(country_codes))
+        return self.code_to_country[unique_country_code]
+
+    def set_country_on_all_areas(self):
+        error_messages = []
+        for area in Area.objects.filter(**self.generation_kwargs):
+            print("Considering area:", area, area.id)
+            enclosing_country_codes = self.get_enclosing_country_codes(area)
+            country = self.get_country_from_codes(enclosing_country_codes)
+            if country and country.code == '?':
+                msg = 'Multiple enclosing country codes {codes} found for area {name} with ID {id}'
+                error_messages.append(msg.format(
+                    codes=unicode(enclosing_country_codes),
+                    name=area.name,
+                    id=area.id))
+            area.country = country
+            area.save()
+        return error_messages
+
+    @cached_property
+    def code_to_country(self):
+        return {country.code: country for country in Country.objects.all()}
+
+    def handle(self, **options):
+        generation_id = options['generation']
+        try:
+            self.generation = Generation.objects.get(pk=generation_id)
+        except Generation.DoesNotExist:
+            raise CommandError('Couldn\'t find the generation {0}'.format(generation_id))
+
+        with transaction.atomic():
+            self.set_country_codes_for_countries()
+            self.ensure_countries_exist()
+            error_messages = self.set_country_on_all_areas()
+            if error_messages:
+                print("Found the following errors while setting .country on all areas:")
+                for error_message in sorted(error_messages):
+                    print(' ', error_message.encode('utf-8'))
+            if not options['commit']:
+                raise Exception('Rolling back since --commit was not specified')


### PR DESCRIPTION
This command:

 - Iterates over every area

 - Takes an arbitrary point within every polygon in that area

 - Finds all the O02 (country-level) areas that contain those points

 - If there's exactly one of those, sets it as the country on the area

 - Otherwise sets it to a special '?' country, and outputs an error
   message describing the ambiguity

The plan is to run this command (*without* --commit) to assess the
number of areas that have ambiguous enclosing areas, and then decide
what do about those cases. (e.g. we could change MapIt's data model to
accommodate multiple countries for an area, making sure not to break the
existing API; we could pick the smaller of the ambiguous regions
(typically more useful information); we could use the special '?'
country for real.)